### PR TITLE
Demonstrate usage of opshin build

### DIFF
--- a/src/week05/scripts/mint.py
+++ b/src/week05/scripts/mint.py
@@ -1,9 +1,6 @@
-import json
-import subprocess
-
 import click
-from opshin.prelude import TxOutRef, TxId
 from opshin import build
+from opshin.prelude import TxOutRef, TxId
 from pycardano import (
     OgmiosChainContext,
     TransactionBuilder,


### PR DESCRIPTION
Version 0.11.0 of opshin introduced an API to build contracts that can be called from within other python code.
This circumvents potential issues with serialization/deserialization of PlutusData being passed around.

This PR demonstrates its usage on the code of week 5.