### PR TITLE
Fix redeemer tag assignment

### DIFF
--- a/src/week02/scripts/collect_gift.py
+++ b/src/week02/scripts/collect_gift.py
@@ -7,7 +7,6 @@ from pycardano import (
     PlutusV2Script,
     plutus_script_hash,
     Redeemer,
-    RedeemerTag,
 )
 
 from src.utils import get_address, get_signing_info, network, ogmios_url
@@ -74,13 +73,13 @@ def main(name: str, script: str):
     # Build the transaction
     # no output is specified since everything minus fees is sent to change address
     if script in ["fourty_two", "fourty_two_typed"]:
-        redeemer = Redeemer(RedeemerTag.SPEND, 42)
+        redeemer = Redeemer(42)
     elif script == "custom_types":
         from src.week02.lecture.custom_types import MySillyRedeemer
 
-        redeemer = Redeemer(RedeemerTag.SPEND, MySillyRedeemer(42))
+        redeemer = Redeemer(MySillyRedeemer(42))
     else:
-        redeemer = Redeemer(RedeemerTag.SPEND, 0)
+        redeemer = Redeemer(0)
     builder = TransactionBuilder(context)
     builder.add_script_input(utxo_to_spend, script=plutus_script, redeemer=redeemer)
     builder.collaterals.append(non_nft_utxo)

--- a/src/week03/scripts/collect_vest.py
+++ b/src/week03/scripts/collect_vest.py
@@ -9,7 +9,6 @@ from pycardano import (
     PlutusV2Script,
     plutus_script_hash,
     Redeemer,
-    RedeemerTag,
     VerificationKeyHash,
 )
 
@@ -77,7 +76,7 @@ def main(name: str, parameterized):
     assert isinstance(non_nft_utxo, UTxO), "No collateral UTxOs found!"
 
     # Make redeemer
-    redeemer = Redeemer(RedeemerTag.SPEND, 0)
+    redeemer = Redeemer(0)
 
     # Build the transaction
     builder = TransactionBuilder(context)

--- a/src/week05/scripts/mint.py
+++ b/src/week05/scripts/mint.py
@@ -7,7 +7,6 @@ from pycardano import (
     TransactionOutput,
     PlutusV2Script,
     MultiAsset,
-    RedeemerTag,
     Redeemer,
     plutus_script_hash,
     Value,

--- a/src/week05/scripts/mint.py
+++ b/src/week05/scripts/mint.py
@@ -79,9 +79,7 @@ def main(
 
     # Build the transaction
     builder = TransactionBuilder(context)
-    builder.add_minting_script(
-        script=plutus_script, redeemer=Redeemer(RedeemerTag.MINT, 0)
-    )
+    builder.add_minting_script(script=plutus_script, redeemer=Redeemer(0))
     builder.mint = MultiAsset.from_primitive({bytes(script_hash): {tn_bytes: amount}})
     builder.add_input(utxo_to_spend)
     builder.add_output(


### PR DESCRIPTION
The minting contract does work only because the redeemer value is 0 - but this 0 is interpreted as execution units and not the intended redeemer.